### PR TITLE
Shuttle tests move at ticks instead of time

### DIFF
--- a/src/Common/Tester/Tester.cpp
+++ b/src/Common/Tester/Tester.cpp
@@ -32,10 +32,11 @@ Tester::Tester() {
 	TestGroup* driveTests = new TestGroup("Drive", { leftDrive, rightDrive });
 	Test* shuttleLift = new SpeedControllerEncoderTest("shuttle lift",
 			CommandBase::shuttle->liftMotor, CommandBase::shuttle->liftEncoder,
-			.25, -.25, 300);
+			.25, -.25, 200);
 	Test* shuttleHomeTest = new ShuttleHomeTest(CommandBase::shuttle->liftMotor,
 			CommandBase::shuttle->lowerLimit, CommandBase::shuttle->upperLimit,
-			CommandBase::shuttle->clampPiston);
+			CommandBase::shuttle->clampPiston,
+			CommandBase::shuttle->liftEncoder);
 	Test* toteFeedTest = new ToteFeedTest(CommandBase::toteFeed->rollers,
 			CommandBase::toteFeed->backSensor, CommandBase::shuttle->toteSensor,
 			CommandBase::shuttle->clampPiston);
@@ -44,12 +45,9 @@ Tester::Tester() {
 	TestGroup* shuttleTests = new TestGroup("Shuttle", { shuttleHomeTest,
 			shuttleLift, toteFeedTest, fingersTest });
 
-	Test* shuttleOpen = new ShuttleTest("ShuttleOpenTest", false, false)
-	;
-	Test* shuttleClamped = new ShuttleTest("ShuttleClampedTest", true, true)
-	;
-	Test* shuttleGrab = new ShuttleTest("ShuttleGrapTest", true, false)
-	;
+	Test* shuttleOpen = new ShuttleTest("ShuttleOpenTest", false, false);
+	Test* shuttleClamped = new ShuttleTest("ShuttleClampedTest", true, true);
+	Test* shuttleGrab = new ShuttleTest("ShuttleGrapTest", true, false);
 	TestGroup* shuttlePistonsTests = new TestGroup("Shuttle Pistons", {
 			shuttleOpen, shuttleClamped, shuttleGrab });
 

--- a/src/Tests/ShuttleHomeTest.h
+++ b/src/Tests/ShuttleHomeTest.h
@@ -15,9 +15,9 @@ namespace tator {
 class ShuttleHomeTest: public Test {
 public:
 	ShuttleHomeTest(SpeedController* speedController, FixedField* lower,
-			FixedField* upper, Solenoid* clamp) :
+			FixedField* upper, Solenoid* clamp, Encoder* liftEncoder) :
 			Test("ShuttleHomeTest"), speedController(speedController), lower(
-					lower), upper(upper), clamp(clamp) {
+					lower), upper(upper), clamp(clamp), liftEncoder(liftEncoder) {
 		unclamped = false;
 		finished = false;
 		upperSensorTripped = false;
@@ -39,11 +39,11 @@ public:
 				unclamped = true;
 			}
 		} else if (!upperSensorTripped) {
-			speedController->Set(-.25);
-			if (time >= 1.5) {
+			speedController->Set(-.30);
+			if (liftEncoder->Get() >= 350) {
 				clamp->Set(false);
 			}
-			if (time >= 3.0) {
+			if (time >= 5.0) {
 				Error("Upper sensor was not tripped after 3 seconds");
 				upperSensorTripped = true;
 				timer.Reset();
@@ -54,10 +54,10 @@ public:
 			}
 		} else {
 			speedController->Set(0);
-			if (time >= 1.5) {
+			if (liftEncoder->Get() <= 350) {
 				clamp->Set(true);
 			}
-			if (time >= 6.0) {
+			if (time >= 10.0) {
 				Error("Lower sensor was not tripped after 6 seconds falling");
 				finished = true;
 			} else if (lower->Get()) {
@@ -85,6 +85,7 @@ private:
 	SpeedController* speedController;
 	FixedField *lower, *upper;
 	Solenoid* clamp;
+	Encoder* liftEncoder;
 	bool unclamped, upperSensorTripped, finished;
 };
 


### PR DESCRIPTION
Changed the tests on the shuttle to clamp based on tick values instead
of times, to make it more reliable.
