### PR TITLE
Fixed a bug which was causing all commands to be created multiple times

### DIFF
--- a/src/Common/Config/Kremlin.cpp
+++ b/src/Common/Config/Kremlin.cpp
@@ -53,8 +53,6 @@
 
 namespace tator {
 
-bool Kremlin::lastTry;
-bool Kremlin::createdCommand;
 std::map<std::string, Kremlin::CommandDetails> Kremlin::commands;
 Logger Kremlin::log("Kremlin");
 
@@ -110,17 +108,18 @@ void Kremlin::CreateNormalCommands() {
 
 void Kremlin::CreateCommands() {
 	Kremlin::CreateNormalCommands();
-	lastTry = false;
+	bool lastTry = false;
+	bool createdCommand = false;
 	do {
-		createdCommand = false;
-		Kremlin::CreateGenericCommandGroups();
+		createdCommand = Kremlin::CreateGenericCommandGroups(lastTry);
 		if (!createdCommand) {
 			lastTry = !lastTry;
 		}
 	} while (createdCommand || lastTry);
 }
 
-void Kremlin::CreateGenericCommandGroups() {
+bool Kremlin::CreateGenericCommandGroups(bool lastTry) {
+	bool createdCommand = false;
 	// Special GenericCommandGroup code
 	for (YAML::Node::iterator it = Config::commands.begin();
 			it != Config::commands.end(); it++) {
@@ -163,6 +162,7 @@ void Kremlin::CreateGenericCommandGroups() {
 			createdCommand = true;
 		}
 	}
+	return createdCommand;
 }
 
 template<typename T>

--- a/src/Common/Config/Kremlin.h
+++ b/src/Common/Config/Kremlin.h
@@ -42,8 +42,6 @@ protected:
 	/// Map of strings to CommandDetails
 	static std::map<std::string, CommandDetails> commands;
 	static Logger log;
-	static bool createdCommand; ///< If this iteration of command creation created a command
-	static bool lastTry; ///< If this iteration of command creation is just to check for problems
 	template<typename T>
 	/**
 	 * Creates the commands for a given class
@@ -53,8 +51,10 @@ protected:
 	/**
 	 * Creates the command groups
 	 * Special code is required to do dependency injection
+	 * @param lastTry If this is the last iteration, meant only to log which commands are missing
+	 * @return If a command was created
 	 */
-	static void CreateGenericCommandGroups();
+	static bool CreateGenericCommandGroups(bool lastTry);
 };
 
 }


### PR DESCRIPTION
Kremlin now only tries to create GenericCommandGroup multiple times (because of dependency injection). Also, I moved GenericCommandGroup code in Kremlin to its own function.

Will probably be merged post-Arizona.
